### PR TITLE
Fix Matrix8x8x2 and style.

### DIFF
--- a/docs/matrix.rst
+++ b/docs/matrix.rst
@@ -27,6 +27,11 @@ Matrices
 
         Get or set the color of a given pixel.
 
+    .. attribute:: framebuffer
+
+        The underlying `FrameBuffer <https://docs.micropython.org/en/latest/esp8266/library/framebuf.html>`_
+        object.
+
 .. class:: Matrix16x18
 
     A double matrix or the matrix wing.


### PR DESCRIPTION
* Matrix8x8x2 now displays correctly (tested on actual hardware)
* Fixed spacing, too long lines, used hex for masks
* Fixed the buffer size to 16 bytes, as that's how much the chip has.